### PR TITLE
GLES support

### DIFF
--- a/cmake/platform/linux/wayland.cmake
+++ b/cmake/platform/linux/wayland.cmake
@@ -1,5 +1,16 @@
-set(PLATFORM_REQUIRED_DEPS OpenGl EGL Waylandpp LibDRM Xkbcommon)
+set(PLATFORM_REQUIRED_DEPS EGL Waylandpp LibDRM Xkbcommon)
 set(PLATFORM_OPTIONAL_DEPS VAAPI)
+
+set(WAYLAND_RENDER_SYSTEM "" CACHE STRING "Render system to use with Wayland: \"gl\" or \"gles\"")
+
+if(WAYLAND_RENDER_SYSTEM STREQUAL "gl")
+  list(APPEND PLATFORM_REQUIRED_DEPS OpenGl)
+elseif(WAYLAND_RENDER_SYSTEM STREQUAL "gles")
+  list(APPEND PLATFORM_REQUIRED_DEPS OpenGLES)
+else()
+  message(SEND_ERROR "You need to decide whether you want to use GL- or GLES-based rendering in combination with the Wayland windowing system. Please set WAYLAND_RENDER_SYSTEM to either \"gl\" or \"gles\". For normal desktop systems, you will usually want to use \"gl\".")
+endif()
+
 set(PLATFORM_GLOBAL_TARGET_DEPS generate-wayland-extra-protocols)
 set(WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 # for wayland-extra-protocols.hpp

--- a/cmake/treedata/linux/subdirs.txt
+++ b/cmake/treedata/linux/subdirs.txt
@@ -9,5 +9,4 @@ xbmc/powermanagement/linux powermanagement/linux
 xbmc/storage/linux         storage/linux
 xbmc/filesystem/posix      filesystem/posix
 xbmc/utils/posix           utils_posix
-xbmc/windowing/egl         windowing/egl
 xbmc/platform/posix        posix

--- a/cmake/treedata/optional/common/imx.txt
+++ b/cmake/treedata/optional/common/imx.txt
@@ -1,0 +1,1 @@
+xbmc/windowing/egl         windowing/egl    # IMX

--- a/xbmc/windowing/WindowingFactory.h
+++ b/xbmc/windowing/WindowingFactory.h
@@ -41,6 +41,9 @@
 #elif defined(HAVE_WAYLAND) && defined(HAS_GL)
 #include "wayland/WinSystemWaylandEGLContextGL.h"
 
+#elif defined(HAVE_WAYLAND) && defined(HAS_GLES)
+#include "wayland/WinSystemWaylandEGLContextGLES.h"
+
 #elif defined(TARGET_LINUX) && defined(HAVE_MIR) && defined(HAS_GL)
 #include "mir/WinSystemMirGLContext.h"
 

--- a/xbmc/windowing/WindowingFactory.h
+++ b/xbmc/windowing/WindowingFactory.h
@@ -39,7 +39,7 @@
 #include "android/WinSystemAndroidGLESContext.h"
 
 #elif defined(HAVE_WAYLAND) && defined(HAS_GL)
-#include "wayland/WinSystemWaylandGLContext.h"
+#include "wayland/WinSystemWaylandEGLContextGL.h"
 
 #elif defined(TARGET_LINUX) && defined(HAVE_MIR) && defined(HAS_GL)
 #include "mir/WinSystemMirGLContext.h"

--- a/xbmc/windowing/egl/CMakeLists.txt
+++ b/xbmc/windowing/egl/CMakeLists.txt
@@ -1,30 +1,11 @@
-if (NOT MIR_FOUND AND NOT X_FOUND AND NOT MMAL_FOUND AND NOT AML_FOUND)
-  if(OPENGLES_FOUND OR AML_FOUND OR IMX_FOUND)
-    set(SOURCES EGLWrapper.cpp)
+set(SOURCES EGLNativeTypeIMX.cpp
+            EGLWrapper.cpp
+            WinSystemEGL.cpp)
 
-    set(HEADERS EGLNativeType.h
-                EGLQuirks.h
-                EGLWrapper.h)
-  endif()
+set(HEADERS EGLNativeType.h
+            EGLNativeTypeIMX.h
+            EGLQuirks.h
+            EGLWrapper.h
+            WinSystemEGL.h)
 
-  if(OPENGLES_FOUND)
-    list(APPEND SOURCES WinSystemEGL.cpp)
-    list(APPEND HEADERS WinSystemEGL.h)
-  endif()
-endif()
-
-if(CORE_SYSTEM_NAME STREQUAL android)
-  list(APPEND SOURCES EGLNativeTypeAndroid.cpp)
-  list(APPEND HEADERS EGLNativeTypeAndroid.h)
-  list(APPEND SOURCES VideoSyncAndroid.h)
-  list(APPEND SOURCES VideoSyncAndroid.cpp)
-endif()
-
-if(IMX_FOUND)
-  list(APPEND SOURCES EGLNativeTypeIMX.cpp)
-  list(APPEND HEADERS EGLNativeTypeIMX.h)
-endif()
-
-if(SOURCES)
-  core_add_library(windowing_egl)
-endif()
+core_add_library(windowing_egl)

--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCES Connection.cpp
             ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp
             WinEventsWayland.cpp
             WinSystemWayland.cpp
-            WinSystemWaylandGLContext.cpp)
+            WinSystemWaylandEGLContext.cpp)
 
 set(HEADERS Connection.h
             Output.h
@@ -25,6 +25,12 @@ set(HEADERS Connection.h
             ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp
             WinEventsWayland.h
             WinSystemWayland.h
-            WinSystemWaylandGLContext.h)
+            WinSystemWaylandEGLContext.h)
+
+if(OPENGL_FOUND)
+  list(APPEND SOURCES WinSystemWaylandEGLContextGL.cpp)
+  list(APPEND HEADERS WinSystemWaylandEGLContextGL.h)
+endif()
+
 
 core_add_library(windowing_WAYLAND)

--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -31,6 +31,10 @@ if(OPENGL_FOUND)
   list(APPEND SOURCES WinSystemWaylandEGLContextGL.cpp)
   list(APPEND HEADERS WinSystemWaylandEGLContextGL.h)
 endif()
+if(OPENGLES_FOUND)
+  list(APPEND SOURCES WinSystemWaylandEGLContextGLES.cpp)
+  list(APPEND HEADERS WinSystemWaylandEGLContextGLES.h)
+endif()
 
 
 core_add_library(windowing_WAYLAND)

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -20,8 +20,6 @@
 #pragma once
 
 #include "GLContextEGL.h"
-#include "rendering/gl/RenderSystemGL.h"
-#include "utils/GlobalsHandling.h"
 #include "WinSystemWayland.h"
 
 namespace KODI
@@ -31,13 +29,12 @@ namespace WINDOWING
 namespace WAYLAND
 {
 
-class CWinSystemWaylandGLContext : public CWinSystemWayland, public CRenderSystemGL
+class CWinSystemWaylandEGLContext : public CWinSystemWayland
 {
 public:
-  CWinSystemWaylandGLContext() = default;
-  virtual ~CWinSystemWaylandGLContext() = default;
+  CWinSystemWaylandEGLContext() = default;
+  virtual ~CWinSystemWaylandEGLContext() = default;
 
-  bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;
@@ -52,16 +49,15 @@ public:
   EGLConfig GetEGLConfig() const;
 
 protected:
-  void SetVSyncImpl(bool enable) override;
-  void PresentRenderImpl(bool rendered) override;
+  /**
+   * Inheriting classes should override InitWindowSystem() without parameters
+   * and call this function there with appropriate parameters
+   */
+  bool InitWindowSystem(EGLint renderableType, EGLint apiType);
 
-private:
-  CGLContextEGL m_glContext;
+  CGLContextEGL m_eglContext;
 };
 
 }
 }
 }
-
-XBMC_GLOBAL_REF(KODI::WINDOWING::WAYLAND::CWinSystemWaylandGLContext, g_Windowing);
-#define g_Windowing XBMC_GLOBAL_USE(KODI::WINDOWING::WAYLAND::CWinSystemWaylandGLContext)

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "WinSystemWaylandEGLContextGL.h"
+
+#include <EGL/egl.h>
+
+#include "utils/log.h"
+
+using namespace KODI::WINDOWING::WAYLAND;
+
+bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
+{
+  return CWinSystemWaylandEGLContext::InitWindowSystem(EGL_OPENGL_BIT, EGL_OPENGL_API);
+}
+
+bool CWinSystemWaylandEGLContextGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+{
+  if (!CWinSystemWaylandEGLContext::SetFullScreen(fullScreen, res, blankOtherDisplays))
+  {
+    return false;
+  }
+
+  // Propagate changed dimensions to render system if necessary
+  if (m_nWidth != CRenderSystemGL::m_width || m_nHeight != CRenderSystemGL::m_height)
+  {
+    CLog::LogF(LOGDEBUG, "Resetting render system to %dx%d", m_nWidth, m_nHeight);
+    if (!CRenderSystemGL::ResetRenderSystem(m_nWidth, m_nHeight, fullScreen, res.fRefreshRate))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void CWinSystemWaylandEGLContextGL::SetVSyncImpl(bool enable)
+{
+  m_eglContext.SetVSync(enable);
+}
+
+void CWinSystemWaylandEGLContextGL::PresentRenderImpl(bool rendered)
+{
+  if (rendered)
+  {
+    m_eglContext.SwapBuffers();
+  }
+}

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "rendering/gl/RenderSystemGL.h"
+#include "utils/GlobalsHandling.h"
+#include "WinSystemWaylandEGLContext.h"
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
+
+class CWinSystemWaylandEGLContextGL : public CWinSystemWaylandEGLContext, public CRenderSystemGL
+{
+public:
+  bool InitWindowSystem() override;
+  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+protected:
+  void SetVSyncImpl(bool enable) override;
+  void PresentRenderImpl(bool rendered) override;
+};
+
+}
+}
+}
+
+XBMC_GLOBAL_REF(KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGL, g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGL)

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "WinSystemWaylandEGLContextGLES.h"
+
+#include <EGL/egl.h>
+
+#include "utils/log.h"
+
+using namespace KODI::WINDOWING::WAYLAND;
+
+bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
+{
+  return CWinSystemWaylandEGLContext::InitWindowSystem(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API);
+}
+
+bool CWinSystemWaylandEGLContextGLES::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+{
+  if (!CWinSystemWaylandEGLContext::SetFullScreen(fullScreen, res, blankOtherDisplays))
+  {
+    return false;
+  }
+
+  // Propagate changed dimensions to render system if necessary
+  if (m_nWidth != CRenderSystemGLES::m_width || m_nHeight != CRenderSystemGLES::m_height)
+  {
+    CLog::LogF(LOGDEBUG, "Resetting render system to %dx%d", m_nWidth, m_nHeight);
+    if (!CRenderSystemGLES::ResetRenderSystem(m_nWidth, m_nHeight, fullScreen, res.fRefreshRate))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void CWinSystemWaylandEGLContextGLES::SetVSyncImpl(bool enable)
+{
+  m_eglContext.SetVSync(enable);
+}
+
+void CWinSystemWaylandEGLContextGLES::PresentRenderImpl(bool rendered)
+{
+  if (rendered)
+  {
+    m_eglContext.SwapBuffers();
+  }
+}

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "rendering/gles/RenderSystemGLES.h"
+#include "utils/GlobalsHandling.h"
+#include "WinSystemWaylandEGLContext.h"
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
+
+class CWinSystemWaylandEGLContextGLES : public CWinSystemWaylandEGLContext, public CRenderSystemGLES
+{
+public:
+  bool InitWindowSystem() override;
+  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+protected:
+  void SetVSyncImpl(bool enable) override;
+  void PresentRenderImpl(bool rendered) override;
+};
+
+}
+}
+}
+
+XBMC_GLOBAL_REF(KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGLES, g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGLES)


### PR DESCRIPTION
CMake was a bit tricky, as `PLATFORM_OPTIONAL_DEPS` isn't enough for some things. Hope my solution is OK and fits in with the rest of the platform system.

Kodi code (`system.h`) assumes that when both GL and GLES are configured, it should use GLES, which I think is not a good idea at least for Wayland. Most people on desktops will have GLES installed as part of Mesa but there is no reason why they should use it normally. So I made sure that full GL is checked first and GLES not even considered when it is found - of course overridable with `-D ENABLE_OPENGL=NO`.